### PR TITLE
PIA-906: Set swift-tools to 5.8 (for XCode 14 compatibility)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "PIAWireguard",
     platforms: [
-      .iOS(.v12), .tvOS(.v17)
+      .iOS(.v12)
     ],
     products: [
         .library(


### PR DESCRIPTION
Set the `xcode-tools` to 5.8 for Xcode 14 compatibility